### PR TITLE
[fix] Replace deprecated methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ const run = async () => {
     }
   } catch(err) {
       if (err) {
-        switch (err.code) {
+        switch (err.status) {
           case 401:
             console.log(chalk.red('Couldn\'t log you in. Please provide correct credentials/token.'));
             break;

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,4 +1,4 @@
-const octokit     = require('@octokit/rest')();
+const Octokit     = require('@octokit/rest');
 const Configstore = require('configstore');
 const pkg         = require('../package.json');
 const _           = require('lodash');
@@ -10,6 +10,8 @@ const inquirer    = require('./inquirer');
 
 const conf = new Configstore(pkg.name);
 
+var octokit;
+
 module.exports = {
 
   getInstance: () => {
@@ -18,14 +20,12 @@ module.exports = {
 
   setGithubCredentials : async () => {
     const credentials = await inquirer.askGithubCredentials();
-    octokit.authenticate(
-      _.extend(
-        {
-          type: 'basic',
-        },
-        credentials
-      )
-    );
+    octokit = new Octokit({
+      auth: {
+        username: credentials.username,
+        password: credentials.password,
+      }
+    })
   },
 
   registerNewToken : async () => {
@@ -33,7 +33,7 @@ module.exports = {
     status.start();
 
     try {
-      const response = await octokit.authorization.create({
+      const response = await octokit.oauthAuthorizations.createAuthorization({
         scopes: ['user', 'public_repo', 'repo', 'repo:status'],
         note: 'ginits, the command-line tool for initalizing Git repos'
       });
@@ -52,10 +52,9 @@ module.exports = {
   },
 
   githubAuth : (token) => {
-    octokit.authenticate({
-      type : 'oauth',
-      token : token
-    });
+    octokit = new Octokit({
+      auth: token
+    })
   },
 
   getStoredGithubToken : () => {

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -24,7 +24,7 @@ module.exports = {
     status.start();
 
     try {
-      const response = await github.repos.create(data);
+      const response = await github.repos.createForAuthenticatedUser(data);
       return response.data.ssh_url;
     } catch(err) {
       throw err;


### PR DESCRIPTION
## Description
Some functionalities of @octokit/rest is deprecated. The deprecated methods used are `octokit.authenticate()`, `octokit.authorization.create()` and `octokit.repos.create()`.

## Key changes
1. Replace three methods.
2. Replace deprecated `err.code` with `err.status`

## Related github issues on octokit/rest
https://github.com/octokit/rest.js/issues/1194

## octokit/rest release note
https://github.com/octokit/rest.js/releases/tag/v15.18.0#deprecations
